### PR TITLE
Fix factory and service name

### DIFF
--- a/rtbkit/plugins/adserver/adserver_connector.cc
+++ b/rtbkit/plugins/adserver/adserver_connector.cc
@@ -213,10 +213,19 @@ void AdServerConnector::registerFactory(std::string const & name, Factory callba
 
 
 std::unique_ptr<AdServerConnector> AdServerConnector::create(
-    std::shared_ptr<ServiceProxies> const & proxies, Json::Value const & json) {
+        std::string const & serviceName, 
+        std::shared_ptr<ServiceProxies> const & proxies, 
+        Json::Value const & json) {
+    
     auto name = json.get("type", "unknown").asString();
     auto factory = getFactory(name);
-    return std::unique_ptr<AdServerConnector>(factory(proxies, json));
+    
+    auto nameService  = serviceName;
+    if(nameService.empty()) {
+        nameService = json.get("name", "adserver").asString();
+    }
+
+    return std::unique_ptr<AdServerConnector>(factory(nameService, proxies, json));
 }
 
 } // namespace RTBKIT

--- a/rtbkit/plugins/adserver/adserver_connector.h
+++ b/rtbkit/plugins/adserver/adserver_connector.h
@@ -87,10 +87,10 @@ struct AdServerConnector : public Datacratic::ServiceBase {
 
     Date startTime_;
 
-    static std::unique_ptr<AdServerConnector> create(std::shared_ptr<ServiceProxies> const & proxies,
+    static std::unique_ptr<AdServerConnector> create(std::string const & serviceName, std::shared_ptr<ServiceProxies> const & proxies,
                                                      Json::Value const & json);
 
-    typedef std::function<AdServerConnector * (std::shared_ptr<ServiceProxies> const & proxies,
+    typedef std::function<AdServerConnector * (std::string const & serviceName, std::shared_ptr<ServiceProxies> const & proxies,
                                                Json::Value const & json)> Factory;
     static void registerFactory(std::string const & name, Factory factory);
 

--- a/rtbkit/plugins/adserver/adserver_runner.cc
+++ b/rtbkit/plugins/adserver/adserver_runner.cc
@@ -58,7 +58,8 @@ int main(int argc, char** argv)
     }
 
     auto proxies = args.makeServiceProxies();
-    auto server = RTBKIT::AdServerConnector::create(proxies, loadJsonFromFile(configuration));
+    auto serviceName = args.serviceName("adServer");
+    auto server = RTBKIT::AdServerConnector::create(serviceName, proxies, loadJsonFromFile(configuration));
     server->start();
 
     while (true) this_thread::sleep_for(chrono::seconds(10));

--- a/rtbkit/plugins/adserver/mock_adserver_connector.cc
+++ b/rtbkit/plugins/adserver/mock_adserver_connector.cc
@@ -12,8 +12,8 @@
 using namespace RTBKIT;
 
 MockAdServerConnector::
-MockAdServerConnector(std::shared_ptr<ServiceProxies> const & proxies, Json::Value const & json) :
-    HttpAdServerConnector(json.get("name", "mock-adserver").asString(), proxies),
+MockAdServerConnector(std::string const & serviceName, std::shared_ptr<ServiceProxies> const & proxies, Json::Value const & json) :
+    HttpAdServerConnector(serviceName, proxies),
     publisher(getServices()->zmqContext) {
 }
 
@@ -89,9 +89,9 @@ namespace {
 struct AtInit {
     AtInit()
     {
-        AdServerConnector::registerFactory("mock", [](std::shared_ptr<ServiceProxies> const & proxies,
+        AdServerConnector::registerFactory("mock", [](std::string const & serviceName, std::shared_ptr<ServiceProxies> const & proxies,
                                                       Json::Value const & json) {
-            auto server = new MockAdServerConnector(proxies, json);
+            auto server = new MockAdServerConnector(serviceName, proxies, json);
 
             int winPort = json.get("winPort", "12340").asInt();
             int eventPort = json.get("eventPort", "12341").asInt();

--- a/rtbkit/plugins/adserver/mock_adserver_connector.h
+++ b/rtbkit/plugins/adserver/mock_adserver_connector.h
@@ -39,7 +39,7 @@ struct MockAdServerConnector : public HttpAdServerConnector
           publisher(getServices()->zmqContext) {
     }
 
-    MockAdServerConnector(std::shared_ptr<ServiceProxies> const & proxies,
+    MockAdServerConnector(std::string const & serviceName, std::shared_ptr<ServiceProxies> const & proxies,
                           Json::Value const & json);
 
     void init(int winPort, int eventPort);

--- a/rtbkit/plugins/adserver/standard_adserver_connector.cc
+++ b/rtbkit/plugins/adserver/standard_adserver_connector.cc
@@ -61,9 +61,9 @@ StandardAdServerConnector(std::shared_ptr<ServiceProxies> & proxy,
 }
 
 StandardAdServerConnector::
-StandardAdServerConnector(std::shared_ptr<ServiceProxies> const & proxies,
+StandardAdServerConnector(std::string const & serviceName, std::shared_ptr<ServiceProxies> const & proxies,
                           Json::Value const & json) :
-    HttpAdServerConnector(json.get("name", "standard-adserver").asString(), proxies),
+    HttpAdServerConnector(serviceName, proxies),
     publisher_(getServices()->zmqContext) {
     int winPort = json.get("winPort", 18143).asInt();
     int eventsPort = json.get("eventsPort", 18144).asInt();
@@ -304,9 +304,8 @@ namespace {
 struct AtInit {
     AtInit()
     {
-        AdServerConnector::registerFactory("standard", [](std::shared_ptr<ServiceProxies> const & proxies,
-                                                          Json::Value const & json) {
-            return new StandardAdServerConnector(proxies, json);
+        AdServerConnector::registerFactory("standard", [](std::string const & serviceName , std::shared_ptr<ServiceProxies> const & proxies, Json::Value const & json) {
+            return new StandardAdServerConnector(serviceName, proxies, json);
         });
     }
 } atInit;

--- a/rtbkit/plugins/adserver/standard_adserver_connector.h
+++ b/rtbkit/plugins/adserver/standard_adserver_connector.h
@@ -39,7 +39,7 @@ struct StandardAdServerConnector : public HttpAdServerConnector
 {
     StandardAdServerConnector(shared_ptr<Datacratic::ServiceProxies> & proxy,
                               const string & serviceName = "StandardAdServer");
-    StandardAdServerConnector(std::shared_ptr<Datacratic::ServiceProxies> const & proxy,
+    StandardAdServerConnector(std::string const & serviceName, std::shared_ptr<Datacratic::ServiceProxies> const & proxy,
                               Json::Value const & json);
 
     void init(StandardAdServerArguments & ssConfig);


### PR DESCRIPTION
It seems, service name on the command line is not take in account.
if we start the service with the factory, we specify the service name (and the tree in graphite also) only from the field name in the config file; If no name are specify, a default name is given.
So the command line service name is never take in account in that case.

Fix this in this PR
