### PR TITLE
Adserver service name

### DIFF
--- a/rtbkit/plugins/adserver/adserver_runner.cc
+++ b/rtbkit/plugins/adserver/adserver_runner.cc
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
     }
 
     auto proxies = args.makeServiceProxies();
-    auto serviceName = args.serviceName("adServer");
+    auto serviceName = args.serviceName("");
     auto server = RTBKIT::AdServerConnector::create(serviceName, proxies, loadJsonFromFile(configuration));
     server->start();
 


### PR DESCRIPTION
The logic is already done in adserver_connector.cc.
So when we put a default value, the logic is not executed.
