### PR TITLE
Reduce number of context switches in agents by 10x (RTBKIT-528)

### DIFF
--- a/rtbkit/plugins/bidding_agent/bidding_agent.cc
+++ b/rtbkit/plugins/bidding_agent/bidding_agent.cc
@@ -87,8 +87,10 @@ jsonParse(const std::string & str)
 
 BiddingAgent::
 BiddingAgent(std::shared_ptr<ServiceProxies> proxies,
-            const std::string & name)
+             const std::string & name,
+             double maxAddedLatency)
     : ServiceBase(name, proxies),
+      MessageLoop(1 /* threads */, maxAddedLatency),
       agentName(name + "_" + to_string(getpid())),
       toRouters(getZmqContext()),
       toPostAuctionServices(getZmqContext()),
@@ -100,8 +102,10 @@ BiddingAgent(std::shared_ptr<ServiceProxies> proxies,
 
 BiddingAgent::
 BiddingAgent(ServiceBase& parent,
-            const std::string & name)
+             const std::string & name,
+             double maxAddedLatency)
     : ServiceBase(name, parent),
+      MessageLoop(1 /* threads */, maxAddedLatency),
       agentName(name + "_" + to_string(getpid())),
       toRouters(getZmqContext()),
       toPostAuctionServices(getZmqContext()),
@@ -177,7 +181,7 @@ init()
     addSource("BiddingAgent::toConfigurationAgent", toConfigurationAgent);
     addSource("BiddingAgent::toRouterChannel", toRouterChannel);
 
-    MessageLoop::init();
+    // No need to init() message loop; it was done in the constructor
 }
 
 void

--- a/rtbkit/plugins/bidding_agent/bidding_agent.h
+++ b/rtbkit/plugins/bidding_agent/bidding_agent.h
@@ -51,9 +51,11 @@ namespace RTBKIT {
 struct BiddingAgent : public ServiceBase, public MessageLoop {
 
     BiddingAgent(std::shared_ptr<ServiceProxies> proxies,
-                const std::string & name = "bidding_agent");
+                 const std::string & name = "bidding_agent",
+                 double maxAddedLatency = 0.005);
     BiddingAgent(ServiceBase & parent,
-                const std::string & name = "bidding_agent");
+                 const std::string & name = "bidding_agent",
+                 double maxAddedLatench = 0.005);
 
     ~BiddingAgent();
 

--- a/rtbkit/testing/agent_context_switch_test.cc
+++ b/rtbkit/testing/agent_context_switch_test.cc
@@ -1,0 +1,47 @@
+/* agent_context_switch_test.cc
+   Jeremy Barnes, 15 June 2014
+   Copyright (c) 2014 Datacratic Inc.  All rights reserved.
+
+   Test for the context switches for the bidding agent.
+*/
+
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include "rtbkit/core/router/router.h"
+#include "rtbkit/core/agent_configuration/agent_configuration_service.h"
+#include "rtbkit/core/agent_configuration/agent_configuration_listener.h"
+#include "soa/service/process_stats.h"
+#include "jml/utils/pair_utils.h"
+#include "jml/arch/timers.h"
+#include "jml/arch/futex.h"
+#include "test_agent.h"
+
+using namespace std;
+using namespace ML;
+using namespace Datacratic;
+using namespace RTBKIT;
+
+
+BOOST_AUTO_TEST_CASE( test_agent_configuration )
+{
+    std::shared_ptr<ServiceProxies> proxies(new ServiceProxies());
+
+    TestAgent agent(proxies, "bidding_agent");
+    agent.init();
+    agent.start();
+
+    ProcessStats stats0(false);
+
+    ML::sleep(1.0);
+
+    ProcessStats stats(false);
+
+    agent.shutdown();
+
+    cerr << "did " << stats.totalContextSwitches() - stats0.totalContextSwitches()
+         << " context switches per second" << endl;
+}
+

--- a/rtbkit/testing/testing.mk
+++ b/rtbkit/testing/testing.mk
@@ -25,3 +25,5 @@ $(eval $(call program,json_listener,boost_program_options services utils))
 $(eval $(call test,creative_configuration_test,rtb_router, boost))
 
 $(eval $(call test,exchange_parsing_from_file_test,openrtb_bid_request rtb_router openrtb_exchange,boost))
+
+$(eval $(call test,agent_context_switch_test,rtb_router bidding_agent,boost))


### PR DESCRIPTION
This changeset adds a test program for context switches (that prints how many an idle agent will do), and changes the default bidding agent maxAddedLatency to 5ms from 0.5ms.  It reduces the number of context switches an idle agent makes to 200 from 2000 per second, at the expense of up to 4.5ms of extra bidding latency.
