### PR TITLE
RTBOPT-832 : fixed win source to output userIds in an array not object, moved method ...

### DIFF
--- a/rtbkit/common/bid_request.cc
+++ b/rtbkit/common/bid_request.cc
@@ -793,6 +793,16 @@ toJsonStr() const
     return boost::trim_copy(toJson().toString());
 }
 
+Json::Value
+UserIds::
+toJsonArray() const
+{
+    Json::Value result(Json::arrayValue);
+    for (auto it = begin(), end = this->end();  it != end;  ++it)
+        result.append(it->second.toString());
+    return result;
+}
+
 UserIds
 UserIds::
 createFromJson(const Json::Value & json)

--- a/rtbkit/common/bid_request.h
+++ b/rtbkit/common/bid_request.h
@@ -193,6 +193,9 @@ struct UserIds : public std::map<std::string, Id> {
     /** Return a canonical stringified JSON version of the bid request. */
     std::string toJsonStr() const;
 
+    /** Return an array of all the userIds as strings without xchg or prov key. */
+    Json::Value toJsonArray() const;
+
     std::string toString() const
     {
         return toJsonStr();

--- a/rtbkit/plugins/adserver/standard_event_source.cc
+++ b/rtbkit/plugins/adserver/standard_event_source.cc
@@ -8,15 +8,6 @@
 
 using namespace RTBKIT;
 
-static Json::Value formatUserIds(const BidRequest& bidRequest)
-{
-    Json::Value userIds(Json::arrayValue);
-    for (const auto &uid: bidRequest.userIds) {
-        userIds.append(uid.second.toString());
-    }
-    return userIds;
-}
-
 StandardEventSource::
 StandardEventSource(NetworkAddress address) :
     EventSource(std::move(address)) {
@@ -37,7 +28,7 @@ sendImpression(const BidRequest& bidRequest, const Bid& bid)
     json["timestamp"] = Date::now().secondsSinceEpoch();
     json["bidRequestId"] = bidRequest.auctionId.toString();
     json["impid"] = bid.adSpotId.toString();
-    json["userIds"] = formatUserIds(bidRequest);
+    json["userIds"] = bidRequest.userIds.toJsonArray();
     json["type"] = "CONVERSION";
     sendEvent(json); 
 }
@@ -51,7 +42,7 @@ sendClick(const BidRequest& bidRequest, const Bid& bid)
     json["timestamp"] = Date::now().secondsSinceEpoch();
     json["bidRequestId"] = bidRequest.auctionId.toString();
     json["impid"] = bid.adSpotId.toString();
-    json["userIds"] = formatUserIds(bidRequest);
+    json["userIds"] = bidRequest.userIds.toJsonArray();
     json["type"] = "CLICK";
     sendEvent(json); 
 }

--- a/rtbkit/plugins/adserver/standard_win_source.cc
+++ b/rtbkit/plugins/adserver/standard_win_source.cc
@@ -30,7 +30,8 @@ sendWin(const BidRequest& bidRequest, const Bid& bid, const Amount& winPrice)
     json["impid"] = bid.adSpotId.toString();
     json["accountId"] = bid.account.toString();
     json["price"] = (double) USD_CPM(winPrice);
-    // json["userIds"].append(bidRequest.userIds.toJson());
+    // The standard protocol assumes userIds will be an array without xchg and prov keys.
+    json["userIds"].append(bidRequest.userIds.toJsonArray());
 
     sendEvent(json);
 }


### PR DESCRIPTION
...from standard_event_source to UserIds object

@jsbejeau @oktal Please validate.
