### PR TITLE
Post auction service can now be sharded for scaling.

### DIFF
--- a/rtbkit/common/common.mk
+++ b/rtbkit/common/common.mk
@@ -20,7 +20,8 @@ LIBRTB_SOURCES := \
 	auction_events.cc \
 	exchange_connector.cc \
 	bidder_interface.cc \
-	win_cost_model.cc
+	win_cost_model.cc \
+	post_auction_proxy.cc
 
 LIBRTB_LINK := \
 	ACE arch utils jsoncpp boost_thread endpoint boost_regex zmq opstats bid_request

--- a/rtbkit/common/post_auction_proxy.cc
+++ b/rtbkit/common/post_auction_proxy.cc
@@ -1,0 +1,68 @@
+/** post_aution_proxy.cc                                 -*- C++ -*-
+    Rémi Attab, 05 Aug 2014
+    Copyright (c) 2014 Datacratic.  All rights reserved.
+
+    Post auction proxy communication thingy.
+
+*/
+
+#include "post_auction_proxy.h"
+
+using namespace std;
+using namespace Datacratic;
+
+namespace RTBKIT {
+
+/******************************************************************************/
+/* POST AUCTION PROXY                                                         */
+/******************************************************************************/
+
+PostAuctionProxy::
+PostAuctionProxy(shared_ptr<ServiceProxies> proxies) :
+    shards(proxies->params.get("postAuctionShards", 1).asInt()),
+    proxies(proxies)
+{}
+
+void
+PostAuctionProxy::
+init()
+{
+    toPostAuction.init(proxies->config);
+    toPostAuction.connectAllServiceProviders("rtbPostAuctionService", "events");
+}
+
+bool
+PostAuctionProxy::
+isConnected() const
+{
+    for (size_t shard = 0; shard < shards; ++shard) {
+        if (!toPostAuction.isConnectedToShard(shard)) return false;
+    }
+
+    return true;
+}
+
+void
+PostAuctionProxy::
+sendAuction(SubmittedAuctionEvent event)
+{
+    size_t shard = event.auctionId.hash() % shards;
+    string str = ML::DB::serializeToString(event);
+
+    // we intentionally drop the message if the shard isn't up.
+    (void) toPostAuction.sendMessageToShard(shard, "AUCTION", move(str));
+}
+
+void
+PostAuctionProxy::
+sendEvent(PostAuctionEvent event)
+{
+    size_t shard = event.auctionId.hash() % shards;
+    string str = ML::DB::serializeToString(event);
+
+    // we intentionally drop the message if the shard isn't up.
+    (void) toPostAuction.sendMessageToShard(shard, print(event.type), str);
+}
+
+
+} // namepsace RTBKIT

--- a/rtbkit/common/post_auction_proxy.h
+++ b/rtbkit/common/post_auction_proxy.h
@@ -1,0 +1,51 @@
+/** post_auction_proxy.h                                 -*- C++ -*-
+    Rémi Attab, 05 Aug 2014
+    Copyright (c) 2014 Datacratic.  All rights reserved.
+
+    Proxy class for the post auction service.
+
+*/
+
+#pragma once
+
+#include "rtbkit/common/auction_events.h"
+#include "soa/service/service_base.h"
+#include "soa/service/zmq_endpoint.h"
+
+namespace RTBKIT {
+
+
+/******************************************************************************/
+/* POST AUCTION PROXY                                                         */
+/******************************************************************************/
+
+/** Event submission proxy for the post auction loop. Takes care of directing
+    messages to the correct post auction shard.
+
+    Requires that the postAuctionShard configuration parameter be provided in
+    the bootstrap.json to determine the number of active post auction shards. If
+    not present, assumes that there's only one active post auction shard.
+ */
+struct PostAuctionProxy
+{
+    PostAuctionProxy(std::shared_ptr<Datacratic::ServiceProxies> proxies);
+
+    void init();
+
+    // Returns true only the proxy is connected to all shards.
+    bool isConnected() const;
+
+    // Sends an auction to the post auction loop.
+    void sendAuction(SubmittedAuctionEvent auction);
+
+    // Sends an event to the post auction loop.
+    void sendEvent(PostAuctionEvent event);
+
+private:
+    size_t shards;
+    std::shared_ptr<Datacratic::ServiceProxies> proxies;
+    Datacratic::ZmqMultipleNamedClientBusProxy toPostAuction;
+
+};
+
+} // namespace RTBKIT

--- a/rtbkit/core/post_auction/post_auction_runner.cc
+++ b/rtbkit/core/post_auction/post_auction_runner.cc
@@ -31,7 +31,7 @@ static Json::Value loadJsonFromFile(const std::string & filename)
 /************************************************************************/
 PostAuctionRunner::
 PostAuctionRunner() :
-    shards(1),
+    shard(1),
     auctionTimeout(EventMatcher::DefaultAuctionTimeout),
     winTimeout(EventMatcher::DefaultWinTimeout),
     bidderConfigurationFile("rtbkit/examples/bidder-config.json"),
@@ -54,8 +54,8 @@ doOptions(int argc, char ** argv,
          "configuration file with bidder interface data")
         ("use-http-banker", bool_switch(&useHttpBanker),
          "Communicate with the MasterBanker over http")
-        ("shards", value<size_t>(&shards),
-         "Number of shards(threads) used for matching.")
+        ("shard,s", value<size_t>(&shard),
+         "Shard index starting at 0 for this post auction loop")
         ("win-seconds", value<float>(&winTimeout),
          "Timeout for storing win auction")
         ("auction-seconds", value<float>(&auctionTimeout),
@@ -97,7 +97,7 @@ init()
 
     postAuctionLoop = std::make_shared<PostAuctionService>(proxies, serviceName);
     postAuctionLoop->initBidderInterface(bidderConfig);
-    postAuctionLoop->init(shards);
+    postAuctionLoop->init(shard);
 
     postAuctionLoop->setWinTimeout(winTimeout);
     postAuctionLoop->setAuctionTimeout(auctionTimeout);

--- a/rtbkit/core/post_auction/post_auction_runner.h
+++ b/rtbkit/core/post_auction/post_auction_runner.h
@@ -26,7 +26,7 @@ struct PostAuctionRunner {
 
     ServiceProxyArguments serviceArgs;
 
-    size_t shards;
+    size_t shard;
     float auctionTimeout;
     float winTimeout;
     std::string bidderConfigurationFile;

--- a/rtbkit/core/post_auction/post_auction_service.h
+++ b/rtbkit/core/post_auction/post_auction_service.h
@@ -45,7 +45,7 @@ struct PostAuctionService : public ServiceBase, public MonitorProvider
 
 
     void initBidderInterface(Json::Value const & json);
-    void init(size_t shards = 1);
+    void init(size_t externalShard = 0, size_t internalShards = 1);
     void start(std::function<void ()> onStop = std::function<void ()>());
     void shutdown();
 
@@ -224,6 +224,7 @@ struct PostAuctionService : public ServiceBase, public MonitorProvider
         Stats(const Stats& other);
         Stats& operator=(const Stats& other);
         Stats& operator-=(const Stats& other);
+        Stats& operator+=(const Stats& other);
 
     } stats;
 
@@ -242,7 +243,7 @@ private:
     /** Initialize all of our connections, hooking everything in to the
         event loop.
     */
-    void initConnections();
+    void initConnections(size_t shard);
     void initMatcher(size_t shards);
 
     void doAuction(std::shared_ptr< SubmittedAuctionEvent> event);

--- a/rtbkit/core/router/router.h
+++ b/rtbkit/core/router/router.h
@@ -28,6 +28,7 @@
 #include <unordered_set>
 #include <thread>
 #include "rtbkit/common/exchange_connector.h"
+#include "rtbkit/common/post_auction_proxy.h"
 #include "rtbkit/core/agent_configuration/blacklist.h"
 #include "rtbkit/core/agent_configuration/agent_configuration_listener.h"
 #include "rtbkit/core/agent_configuration/agent_config.h"
@@ -386,7 +387,7 @@ protected:
 
 public:
     // Connection to the post auction loop
-    ZmqNamedProxy postAuctionEndpoint;
+    PostAuctionProxy postAuctionEndpoint;
 
     void updateAllAgents();
 

--- a/rtbkit/plugins/adserver/adserver_connector.cc
+++ b/rtbkit/plugins/adserver/adserver_connector.cc
@@ -25,7 +25,7 @@ AdServerConnector::
 AdServerConnector(const string & serviceName,
                   const shared_ptr<Datacratic::ServiceProxies> & proxy)
     : ServiceBase(serviceName, proxy),
-      toPostAuctionService_(proxy->zmqContext)
+      toPostAuctionService_(proxy)
 {
 }
 
@@ -43,21 +43,7 @@ init(shared_ptr<ConfigurationService> config)
     registerServiceProvider(serviceName_, { "adServer" });
     services->config->removePath(serviceName());
 
-    toPostAuctionService_.init(config, ZMQ_XREQ);
-    toPostAuctionService_.connectToServiceClass("rtbPostAuctionService",
-                                                "events");
-
-#if 0 // later, for when we have multiple
-
-    toPostAuctionServices_.init(getServices()->config, name);
-    toPostAuctionServices_.connectHandler = [=] (const string & connectedTo) {
-        cerr << "AdServerConnector is connected to post auction service "
-        << connectedTo << endl;
-    };
-    toPostAuctionServices_.connectAllServiceProviders("rtbPostAuctionService",
-                                                      "agents");
-    toPostAuctionServices_.connectToServiceClass();
-#endif
+    toPostAuctionService_.init();
 }
 
 void
@@ -107,8 +93,7 @@ publishWin(const Id & bidRequestId,
     event.account = account;
     event.bidTimestamp = bidTimestamp;
 
-    string str = ML::DB::serializeToString(event);
-    toPostAuctionService_.sendMessage("WIN", str);
+    toPostAuctionService_.sendEvent(event);
 }
 
 void
@@ -132,8 +117,7 @@ publishLoss(const Id & bidRequestId,
     event.account = account;
     event.bidTimestamp = bidTimestamp;
 
-    string str = ML::DB::serializeToString(event);
-    toPostAuctionService_.sendMessage("LOSS", str);
+    toPostAuctionService_.sendEvent(event);
 }
 
 void
@@ -157,8 +141,7 @@ publishCampaignEvent(const string & label,
     event.uids = ids;
     event.metadata = impressionMeta;
 
-    string str = ML::DB::serializeToString(event);
-    toPostAuctionService_.sendMessage("EVENT", str);
+    toPostAuctionService_.sendEvent(event);
 }
 
 void

--- a/rtbkit/plugins/adserver/adserver_connector.h
+++ b/rtbkit/plugins/adserver/adserver_connector.h
@@ -15,6 +15,7 @@
 #include "rtbkit/common/json_holder.h"
 #include "rtbkit/common/bid_request.h"
 #include "rtbkit/common/account_key.h"
+#include "rtbkit/common/post_auction_proxy.h"
 
 
 namespace RTBKIT {
@@ -96,7 +97,7 @@ struct AdServerConnector : public Datacratic::ServiceBase {
 
 private:
     // Connection to the post auction loops
-    ZmqNamedProxy toPostAuctionService_;
+    PostAuctionProxy toPostAuctionService_;
 
     // later... when we have multiple services
     //ZmqMultipleNamedClientBusProxy toPostAuctionServices;


### PR DESCRIPTION
Sharding is done at the router and ad server level where the correct
shard is chosen using the hash of the auction id modulo the number of
shards provided via the postAuctionShards parameter in the
bootstrap.json.

The post auction loop must also declare itself as a given shard using
the shard command line argument.
