### PR TITLE
RTBKIT-608: Avoid crashing the SlaveBanker when reauthorizeBudget fails

### DIFF
--- a/rtbkit/core/banker/slave_banker.h
+++ b/rtbkit/core/banker/slave_banker.h
@@ -245,6 +245,7 @@ private:
     typedef ML::Spinlock Lock;
     mutable Lock syncLock;
     Datacratic::Date lastSync;
+    Datacratic::Date lastReauthorize;
 
     
     /** Periodically we report spend to the banker.*/


### PR DESCRIPTION
Make sure that the system goes into slowmode when the SlaveBanker is unable to report the spent budget instead of crashing.
