### PR TITLE
Enforce SLA time limit

### DIFF
--- a/rtbkit/plugins/exchange/http_exchange_connector.cc
+++ b/rtbkit/plugins/exchange/http_exchange_connector.cc
@@ -61,6 +61,7 @@ postConstructorInit()
     pingTimeUnknownHostsMs = 20;
     auctionVerb = "POST";
     auctionResource = "/";
+    absoluteTimeMax = 50.0;
 
     numServingRequest = 0;
 
@@ -104,6 +105,7 @@ configure(const Json::Value & parameters)
     getParam(parameters, auctionVerb, "auctionVerb");
     getParam(parameters, pingTimesByHostMs, "pingTimesByHostMs");
     getParam(parameters, pingTimeUnknownHostsMs, "pingTimeUnknownHostsMs");
+    getParam(parameters, absoluteTimeMax, "absoluteTimeMax");
 
     if (parameters.isMember("realTimePolling"))
         realTimePolling(parameters["realTimePolling"].asBool());
@@ -119,7 +121,8 @@ configureHttp(int numThreads,
               const std::string & auctionResource,
               const std::string & auctionVerb,
               int realTimePriority,
-              bool realTimePolling)
+              bool realTimePolling,
+              double absoluteTimeMax)
 {
     this->numThreads = numThreads;
     this->realTimePriority = realTimePriority;
@@ -130,6 +133,7 @@ configureHttp(int numThreads,
     this->auctionResource = auctionResource;
     this->auctionVerb = auctionVerb;
     this->realTimePolling(realTimePolling);
+    this->absoluteTimeMax = absoluteTimeMax;
 }
 
 void

--- a/rtbkit/plugins/exchange/http_exchange_connector.h
+++ b/rtbkit/plugins/exchange/http_exchange_connector.h
@@ -68,7 +68,8 @@ struct HttpExchangeConnector
                        const std::string & auctionResource = "/auctions",
                        const std::string & auctionVerb = "POST",
                        int realTimePriority = -1,
-                       bool realTimePolling = false);
+                       bool realTimePolling = false,
+                       double absoluteTimeMax = 50.0);
 
     /** Start the exchange connector running */
     virtual void start();
@@ -267,6 +268,7 @@ protected:
     int backlog;
     std::string auctionResource;
     std::string auctionVerb;
+    double absoluteTimeMax;
 
     /// The ping time to known hosts in milliseconds
     std::unordered_map<std::string, float> pingTimesByHostMs;

--- a/rtbkit/plugins/exchange/openrtb_exchange_connector.cc
+++ b/rtbkit/plugins/exchange/openrtb_exchange_connector.cc
@@ -191,7 +191,7 @@ getTimeAvailableMs(HttpAuctionHandler & connection,
         return 30.0;
     
     int tmax = atoi(payload.c_str() + pos + toFind.length());
-    return tmax;
+    return (absoluteTimeMax < tmax) ? absoluteTimeMax : tmax;
 }
 
 HttpResponse


### PR DESCRIPTION
Added an absolute time maximum variable when reading a bid request to limit the maximum available time given for request processing. The absolute time max is settable in router-config.json.
