### PR TITLE
Router handling of deleted agent configurations

### DIFF
--- a/rtbkit/core/router/router.cc
+++ b/rtbkit/core/router/router.cc
@@ -625,12 +625,7 @@ run()
 
             std::pair<std::string, std::shared_ptr<const AgentConfig> > config;
             while (configBuffer.tryPop(config)) {
-                if (!config.second) {
-                    cerr << "agent " << config.first << " lost configuration" << endl;
-                }
-                else {
-                    doConfig(config.first, config.second);
-                }
+                doConfig(config.first, config.second);
             }
 
             recordTime("doConfig", atStart);
@@ -2470,34 +2465,42 @@ doConfig(const std::string & agent,
          std::shared_ptr<const AgentConfig> config)
 {
     RouterProfiler profiler(dutyCycleCurrent.nsConfig);
-    //const string fName = "Router::doConfig:";
-    logMessage("CONFIG", agent, boost::trim_copy(config->toJson().toString()));
-    logMessageToAnalytics("CONFIG", agent, boost::trim_copy(config->toJson().toString()));
 
-    // TODO: no need for this...
-    auto newConfig = std::make_shared<AgentConfig>(*config);
-    if (newConfig->roundRobinGroup == "")
-        newConfig->roundRobinGroup = agent;
+    if (!config) {
+        cerr << "agent " << agent << " lost configuration" << endl;
+        filters.removeConfig(agent);
+        auto it = agents.find(agent);
+        ExcAssert(it != std::end(agents));
+        agents.erase(it);
+    } else {
+        AgentInfo & info = agents[agent];
+        logMessage("CONFIG", agent, boost::trim_copy(config->toJson().toString()));
+        logMessageToAnalytics("CONFIG", agent, boost::trim_copy(config->toJson().toString()));
 
-    AgentInfo & info = agents[agent];
+        // TODO: no need for this...
+        auto newConfig = std::make_shared<AgentConfig>(*config);
+        if (newConfig->roundRobinGroup == "")
+            newConfig->roundRobinGroup = agent;
 
-    if (info.configured) {
-        unconfigure(agent, *info.config);
-        info.configured = false;
+
+        if (info.configured) {
+            unconfigure(agent, *info.config);
+            info.configured = false;
+        }
+
+        info.config = newConfig;
+        //cerr << "configured " << agent << " strategy : " << info.config->strategy << " campaign "
+        //     <<  info.config->campaign << endl;
+
+        string bidRequestFormat = "jsonRaw";
+        info.setBidRequestFormat(bidRequestFormat);
+
+        configure(agent, *newConfig);
+        info.configured = true;
+        bidder->sendMessage(config, agent, "GOTCONFIG");
+
+        info.filterIndex = filters.addConfig(agent, info);
     }
-
-    info.config = newConfig;
-    //cerr << "configured " << agent << " strategy : " << info.config->strategy << " campaign "
-    //     <<  info.config->campaign << endl;
-
-    string bidRequestFormat = "jsonRaw";
-    info.setBidRequestFormat(bidRequestFormat);
-
-    configure(agent, *newConfig);
-    info.configured = true;
-    bidder->sendMessage(config, agent, "GOTCONFIG");
-
-    info.filterIndex = filters.addConfig(agent, info);
 
     // Broadcast that we have a new agent or it has a new configuration
     updateAllAgents();

--- a/rtbkit/plugins/bidder_interface/http_bidder_interface.cc
+++ b/rtbkit/plugins/bidder_interface/http_bidder_interface.cc
@@ -143,7 +143,27 @@ void HttpBidderInterface::sendAuctionMessage(std::shared_ptr<Auction> const & au
                 [&](const pair<string, BidInfo> &bidder)
         {
             std::string agent = bidder.first;
-            const auto &info = router->agents[agent];
+            /* Since it is possible to delete a configuration from the REST interface of
+             * the agent configuration service, the user might delete the configuration
+             * while some requests for this configuration are already in flight. When
+             * that happens, since we're capturing our context by copy in the closure,
+             * we hold a "private" copy of the current agents and their configurations,
+             * which means that we might still hold configurations that have been deleted
+             * and erased in the router.
+             *
+             * This is why we are checking if the agent still exists. If not, we're skipping
+             * it. This is not ideal and introduces an extra check but this is the simplest way
+             * Note that this will be trigger the "couldn't fint configuration for
+             * externalId" error below. In other words, all requests that are "in flight"
+             * for a configuration that has been deleted will trigger a logging message.
+             * We will return a 204 for these requests
+             */
+            auto agentIt = router->agents.find(agent);
+            if (agentIt == std::end(router->agents)) {
+                return false;
+            }
+            const auto &info = agentIt->second;
+            ExcAssert(info.config);
             return info.config->externalId == externalId;
         });
 


### PR DESCRIPTION
When using the HttpBidderInterface, the user has to "manually" push the agent configuration to the ACS through the correct REST call.

When one wants to stop the traffic from being sent to the bidder (let's say a python bidder), one must remove the configuration from the ACS through the REST interface.
The router was not correctly handling configurations that were removed. The agent still was in memory and the configuration. This patch removes the agent from the internal
storage table of the router and removes the config from the filters as well so that a deleted configuration won't be a "potential bidder" anymore.