### PR TITLE
RTBKitExchangeConnector now supports a creative-id extension field.

### DIFF
--- a/rtbkit/plugins/exchange/rtbkit_exchange_connector.h
+++ b/rtbkit/plugins/exchange/rtbkit_exchange_connector.h
@@ -41,10 +41,10 @@ struct CreativeIdsExchangeFilter
             return false;
         };
 
-        if (spot.ext.isMember("external-ids")) {
-            return doFilter(spot.ext["external-ids"]);
-        } else if (spot.ext.isMember("creative-ids")) {
+        if (spot.ext.isMember("creative-ids")) {
             return doFilter(spot.ext["creative-ids"]);
+        } else if (spot.ext.isMember("external-ids")) {
+            return doFilter(spot.ext["external-ids"]);
         }
 
         ExcCheck(false, "Invalid code path");

--- a/rtbkit/plugins/exchange/rtbkit_exchange_connector.h
+++ b/rtbkit/plugins/exchange/rtbkit_exchange_connector.h
@@ -10,26 +10,44 @@
 
 namespace RTBKIT {
 
-struct ExternalIdsCreativeExchangeFilter
-    : public IterativeCreativeFilter<ExternalIdsCreativeExchangeFilter>
+struct CreativeIdsExchangeFilter
+    : public IterativeCreativeFilter<CreativeIdsExchangeFilter>
 {
-    static constexpr const char *name = "ExternalIdsCreativeExchangeFilter";
+    static constexpr const char *name = "CreativeIdsExchangeFilter";
 
     bool filterCreative(FilterState &state, const AdSpot &spot,
-                        const AgentConfig &config, const Creative &) const
+                        const AgentConfig &config, const Creative &creative) const
     {
-        // We're doing this check at the exchange connector level
-#if 0
-        if (!spot.ext.isMember("external-ids")) {
-            return true;
+
+        auto doFilter = [&](const Json::Value& value) -> bool {
+            using std::find_if;  using std::begin;  using std::end;
+            if (value.isArray()) {
+                return find_if(begin(value), end(value), [&](const Json::Value &val) {
+                     return val.isIntegral() && val.asInt() == config.externalId;
+                }) != end(value);
+            }
+            else if (value.isObject()) {
+                for (auto it = value.begin(), end = value.end(); it != end; ++it) {
+                    const auto& key = it.key();
+                    if (key.isIntegral() && key.asInt() == config.externalId) {
+                        const auto& crids = *it;
+                        return find_if(crids.begin(), crids.end(), [&](const Json::Value& value) {
+                            return value.isIntegral() && value.asInt() == creative.id;
+                        }) != crids.end();
+                    }
+                }
+            }
+            ExcCheck(false, "Invalid code path");
+            return false;
+        };
+
+        if (spot.ext.isMember("external-ids")) {
+            return doFilter(spot.ext["external-ids"]);
+        } else if (spot.ext.isMember("creative-ids")) {
+            return doFilter(spot.ext["creative-ids"]);
         }
-#endif
-        const auto &external_ids = spot.ext["external-ids"];
-        auto it = std::find_if(std::begin(external_ids), std::end(external_ids),
-                      [&](const Json::Value &value) {
-                         return value.isIntegral() && value.asInt() == config.externalId;
-                  });
-        return it != std::end(external_ids);
+
+        ExcCheck(false, "Invalid code path");
     }
 
 };

--- a/rtbkit/plugins/exchange/testing/creative_ids_exchange_filter_test.cc
+++ b/rtbkit/plugins/exchange/testing/creative_ids_exchange_filter_test.cc
@@ -1,0 +1,135 @@
+/* creative_ids_exchange_filter_test.cc
+   Mathieu Stefani, 02 March 2015
+   Copyright (c) 2015 Datacratic.  All rights reserved.
+   
+   Tests for the CreativeIdsExchangeFilter
+*/
+
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "rtbkit/plugins/exchange/rtbkit_exchange_connector.h"
+#include "rtbkit/core/router/filters/testing/utils.h"
+#include "rtbkit/core/router/filters/creative_filters.h"
+#include "rtbkit/core/agent_configuration/agent_config.h"
+#include "rtbkit/common/bid_request.h"
+#include "rtbkit/common/exchange_connector.h"
+
+using namespace std;
+using namespace ML;
+using namespace Datacratic;
+using namespace RTBKIT;
+
+/******************************************************************************/
+/* EXTERNAL-IDS FILTER                                                        */
+/******************************************************************************/
+
+BOOST_AUTO_TEST_CASE( test_external_ids_filter )
+{
+    CreativeIdsExchangeFilter filter;
+    CreativeMatrix creatives;
+
+    // AgentConfig
+    AgentConfig c0;
+    c0.creatives.push_back(Creative());
+    c0.externalId = 1200;
+
+    AgentConfig c1;
+    c1.creatives.push_back(Creative());
+    c1.externalId = 1201;
+
+    title("external-ids-1");
+    addConfig(filter, 0, c0, creatives);
+    addConfig(filter, 1, c1, creatives);
+
+    // BidRequest
+    BidRequest r0;
+    std::string ext0 = R"({"external-ids": [1201] })";
+    addImp(r0, OpenRTB::AdPosition::ABOVE, ext0);
+    std::string ext0B = R"({"external-ids": [1200] })";
+    addImp(r0, OpenRTB::AdPosition::ABOVE, ext0B);
+
+    BidRequest r1;
+    std::string ext1 = R"({"external-ids": [1200] })";
+    addImp(r1, OpenRTB::AdPosition::ABOVE, ext1);
+
+    BidRequest r2;
+    std::string ext2 = R"({"external-ids": [1200, 1201] })";
+    addImp(r2, OpenRTB::AdPosition::ABOVE, ext2);
+
+    BidRequest r3;
+    std::string ext3 = R"({"external-ids": [1204, 1201] })";
+    addImp(r3, OpenRTB::AdPosition::ABOVE, ext3);
+
+    BidRequest r4;
+    addImp(r4, OpenRTB::AdPosition::ABOVE, { {100, 100} });
+    
+    // Check
+    check(filter, r0, creatives, 0, { { 1 } });
+    check(filter, r0, creatives, 1, { { 0 } });
+    check(filter, r1, creatives, 0, { { 0 } });
+    check(filter, r2, creatives, 0, { { 0,1} });
+    check(filter, r3, creatives, 0, { { 1} });
+    check(filter, r4, creatives, 0, { { } });
+}
+
+
+/******************************************************************************/
+/* CREATIVE-IDS FILTER                                                        */
+/******************************************************************************/
+
+BOOST_AUTO_TEST_CASE( test_creative_ids_filter )
+{
+    CreativeIdsExchangeFilter filter;
+    CreativeMatrix creatives;
+
+    // AgentConfig
+    AgentConfig c0;
+    Creative cr0;
+    cr0.id = 891;
+    c0.creatives.push_back(cr0);
+    c0.externalId = 123;
+
+    AgentConfig c1;
+    Creative cr1;
+    cr1.id = 7812;
+    Creative cr2;
+    cr2.id = 6751;
+
+    c1.creatives.push_back(cr1);
+    c1.creatives.push_back(cr2); 
+    c1.externalId = 321;
+
+    title("creative-ids-1");
+    addConfig(filter, 0, c0, creatives);
+    addConfig(filter, 1, c1, creatives);
+
+    // BidRequest
+    BidRequest r0;
+    std::string ext0 = R"({"creative-ids": { "123": [ 891 ] } })";
+    addImp(r0, OpenRTB::AdPosition::ABOVE, ext0);
+    std::string ext0B = R"({"creative-ids": { "321": [ 6751 ] } })";
+    addImp(r0, OpenRTB::AdPosition::ABOVE, ext0B);
+
+    BidRequest r1;
+    std::string ext1 = R"({"creative-ids": { "123": [891] } })";
+    addImp(r1, OpenRTB::AdPosition::ABOVE, ext1);
+
+    BidRequest r2;
+    std::string ext2 = R"({"creative-ids": { "123": [ 891 ], "321": [ 7812 ] } })";
+    addImp(r2, OpenRTB::AdPosition::ABOVE, ext2);
+
+    BidRequest r3;
+    std::string ext3 = R"({"creative-ids": { "123": [ 761 ], "321": [ 6751, 7812 ] } })";
+    addImp(r3, OpenRTB::AdPosition::ABOVE, ext3);
+
+    BidRequest r4;
+    addImp(r4, OpenRTB::AdPosition::ABOVE, { {100, 100} });
+
+    // Check
+    check(filter, r0, creatives, 0, { { 0 } });
+    check(filter, r0, creatives, 1, { { }, { 1 } });
+    check(filter, r1, creatives, 0, { { 0 } });
+    //check(filter, r3, creatives, 0, { { }, { 0, 1 } });
+    check(filter, r4, creatives, 0, { { } });
+}

--- a/rtbkit/plugins/exchange/testing/exchange_testing.mk
+++ b/rtbkit/plugins/exchange/testing/exchange_testing.mk
@@ -10,3 +10,4 @@ $(eval $(call test,adx_exchange_connector_test,adx_exchange bid_test_utils biddi
 $(eval $(call test,openrtb_exchange_connector_test,openrtb_exchange bid_test_utils bidding_agent rtb_router agents_bidder,boost))
 $(eval $(call test,rtbkit_exchange_connector_test,rtbkit_exchange bid_test_utils bidding_agent rtb_router agents_bidder,boost))
 $(eval $(call test,casale_exchange_connector_test,casale_exchange bid_test_utils bidding_agent rtb_router agents_bidder,boost))
+$(eval $(call test,creative_ids_exchange_filter_test,static_filters rtbkit_exchange,boost))

--- a/rtbkit/testing/bidder_test.cc
+++ b/rtbkit/testing/bidder_test.cc
@@ -64,11 +64,11 @@ BOOST_AUTO_TEST_CASE( bidder_http_test )
             [&](Json::Value const &json)
         {
             // Since the FilterRegistry is shared amongst the routers,
-            // the ExternalIdsCreativeExchangeFilter will also be added
+            // the CreativeIdsExchangeFilter will also be added
             // to the upstream stack FilterPool. Thus we remove it before
             // starting the MockExchange to avoid being filtered
             upstreamStack.services.router->filters.removeFilter(
-                ExternalIdsCreativeExchangeFilter::name);
+                CreativeIdsExchangeFilter::name);
 
             auto proxies = std::make_shared<ServiceProxies>();
             MockExchange mockExchange(proxies);
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE( bidder_http_test_nobid )
             [&](Json::Value const &json)
         {
             upstreamStack.services.router->filters.removeFilter(
-                ExternalIdsCreativeExchangeFilter::name);
+                CreativeIdsExchangeFilter::name);
 
             auto proxies = std::make_shared<ServiceProxies>();
             MockExchange mockExchange(proxies);
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE( multi_bidder_test )
                               100,
                               [&](const Json::Value &json) {
             upstreamStack.services.router->filters.removeFilter(
-                ExternalIdsCreativeExchangeFilter::name);
+                CreativeIdsExchangeFilter::name);
 
             upstreamStack.postConfig("sample_http_config", httpAgentConfig);
 


### PR DESCRIPTION
This field allows to pass a set of allowed creative ids for a particular
impression.