### PR TITLE
Video creative

### DIFF
--- a/rtbkit/core/agent_configuration/agent_config.cc
+++ b/rtbkit/core/agent_configuration/agent_config.cc
@@ -89,16 +89,21 @@ fromJson(const Json::Value & val)
         }
     }
 
-    const std::string type_ = val["type"].asString();
-    if (type_ == "video") {
-        duration = val["duration"].asUInt();
-        bitrate = val["bitrate"].asUInt();
-        type = Type::Video;
-    } else if (type_ == "image") {
+    if (val.isMember("type")) {
+        const std::string type_ = val["type"].asString();
+        if (type_ == "video") {
+            duration = val["duration"].asUInt();
+            bitrate = val["bitrate"].asUInt();
+            type = Type::Video;
+        } else if (type_ == "image") {
+            type = Type::Image;
+        }
+        else {
+            throw ML::Exception("Unknown type '%s'", type_.c_str());
+        }
+    } else {
+        // For backward compatibility, take 'Image' by default
         type = Type::Image;
-    }
-    else {
-        throw ML::Exception("Unknown type '%s'", type_.c_str());
     }
 
 }

--- a/rtbkit/core/agent_configuration/agent_config.h
+++ b/rtbkit/core/agent_configuration/agent_config.h
@@ -30,9 +30,16 @@ struct ExchangeConnector;
 /* CREATIVE                                                                  */
 /*****************************************************************************/
 
-/** Describes a creative that a agent has available. */
+/** Describes a creative that an agent has available.
+
+    A creative is a general-purpose entity that can represent either an image
+    or a video
+ */
 
 struct Creative {
+
+    enum class Type { Image, Video };
+
     Creative(int width = 0, int height = 0, std::string name = "", int id = -1,
             const std::string dealId = "");
 
@@ -49,6 +56,10 @@ struct Creative {
     /// Purely for information (used internally)
     std::string name;
     int id;
+
+    /// Video creative information
+    uint32_t duration;
+    uint64_t bitrate;
 
     /// Configuration values; per provider
     /// eg: OpenRTB, ...
@@ -109,6 +120,15 @@ struct Creative {
     /** Is this creative biddable on the given exchange and protocol version? */
     bool biddable(const std::string & exchange,
                   const std::string & protocolVersion) const;
+
+    static Creative image(int width, int height, std::string name = "", int id = -1, std::string dealId = "");
+    static Creative video(int width, int height, uint32_t duration, uint64_t bitrate,
+                std::string name = "", int id = -1, std::string dealId = "");
+
+private:
+    Type type;
+
+    std::string typeString() const;
 };
 
 


### PR DESCRIPTION
Until now, a Creative was only an image that could be served in response to banner impressions.

Since we now support video impressions, we needed a way to support video content through creatives. This PullRequest extends the current Creative class by adding some informations into it like video duration and bitrate in case of a video. This means that a Creative can now represent either a banner image or a video.