### PR TITLE
Improved the way RTBKit handles the creative-ids:

### DIFF
--- a/rtbkit/plugins/bidder_interface/http_bidder_interface.cc
+++ b/rtbkit/plugins/bidder_interface/http_bidder_interface.cc
@@ -623,12 +623,15 @@ void HttpBidderInterface::tagRequest(OpenRTB::BidRequest &request,
             auto &externalIds = imp.ext["external-ids"];
             externalIds.append(agentConfig->externalId);
 
-            auto& creativesExtField = imp.ext["creative-indexes"];
+            auto& creativesExtField = imp.ext["creative-ids"];
 
 
             auto &creativesList = creativesExtField[std::to_string(agentConfig->externalId)];
+            const auto& creatives = agentConfig->creatives;
             for (int index: creativeIndexes) {
-                creativesList.append(index);
+                ExcAssert(index < creatives.size());
+
+                creativesList.append(creatives[index].id);
             }
         }
 

--- a/rtbkit/plugins/exchange/rtbkit_exchange_connector.h
+++ b/rtbkit/plugins/exchange/rtbkit_exchange_connector.h
@@ -10,6 +10,71 @@
 
 namespace RTBKIT {
 
+namespace {
+
+    /* Function to compare a plain int (signed or unsigned) to a string
+
+       We use this function to avoid allocating too much in the filter below
+       when we compare ids that are in the json
+
+       The function will throw if the @str parameter is not a valid number
+       Note that this function is not safe at all as it does not do any
+       overflow checking
+    */
+
+    bool string_int_equals(const char* str, int value) {
+        if (!str) return false;
+        if (str[0] == 0) return false;
+
+        /* Fast path, kinda */
+
+        if (value < 0 && str[0] != '-') return false;
+        if (value > 0 && str[0] == '-') return false;
+
+        /* Slow path */
+
+        /* Compute the length and check if there is any non-digit character
+           at the same time
+        */
+        const size_t len = [&]() {
+            size_t index = 0;
+
+            int c;
+            while ((c = str[index]) != 0) {
+                if (index == 0 && c != '-' && !isdigit(c))
+                    throw std::invalid_argument("Not a valid number");
+
+                ++index;
+            }
+
+            return index;
+        }();
+
+        if (value < 0)
+            value = -value;
+
+        size_t i = len - 1;
+
+        auto to_int = [](char c) {
+            return c - '0';
+        };
+
+        do {
+            const char digitChar = str[i];
+
+            const int currentDigit = value % 10;
+            if (to_int(digitChar) != currentDigit) return false;
+
+            value /= 10;
+            if (i == 0) break;
+            else --i;
+        } while (value > 0);
+
+        return value == 0 && i == 0;
+    }
+}
+
+
 struct CreativeIdsExchangeFilter
     : public IterativeCreativeFilter<CreativeIdsExchangeFilter>
 {
@@ -18,42 +83,54 @@ struct CreativeIdsExchangeFilter
     bool filterCreative(FilterState &state, const AdSpot &spot,
                         const AgentConfig &config, const Creative &creative) const
     {
-
-        auto doFilter = [&](const Json::Value& value) -> bool {
-            using std::find_if;  using std::begin;  using std::end;
-            using std::stoi;
-            if (value.isArray()) {
-                return find_if(begin(value), end(value), [&](const Json::Value &val) {
-                     return val.isIntegral() && val.asInt() == config.externalId;
-                }) != end(value);
-            }
-            else if (value.isObject()) {
-                char id[32];
-                snprintf(id, sizeof(id)-1, "%d", (int) config.externalId);
-                for (auto it = value.begin(), end = value.end(); it != end; ++it) {
-                    auto key = it.memberNameC();
-                    try {
-                        if (strcmp(id, key) == 0) {
-                            const auto& crids = *it;
-                            return find_if(crids.begin(), crids.end(), [&](const Json::Value& value) {
-                                return value.isIntegral() && value.asInt() == creative.id;
-                            }) != crids.end();
-                        }
-                    } catch (const std::invalid_argument&) {
-                        return false;
-                    }
-                }
-            }
-            else {
-                ExcCheck(false, "Invalid code path");
-            }
-            return false;
-        };
-
         if (spot.ext.isMember("creative-ids")) {
-            return doFilter(spot.ext["creative-ids"]);
+            return filterCreativeIds(config, creative, spot.ext["creative-ids"]);
         } else if (spot.ext.isMember("external-ids")) {
-            return doFilter(spot.ext["external-ids"]);
+            return filterExternalIds(config, spot.ext["external-ids"]);
+        }
+
+        return false;
+    }
+
+private:
+    bool filterExternalIds(
+            const AgentConfig& config, const Json::Value& extIds) const
+    {
+        ExcAssert(extIds.isArray());
+
+        using std::find_if;
+        using std::begin;   using std::end;
+
+        return find_if(
+            begin(extIds), end(extIds),
+            [&](const Json::Value &extId) {
+                 return extId.isIntegral() && extId.asInt() == config.externalId;
+            }
+        ) != end(extIds);
+
+    }
+
+    bool filterCreativeIds(
+            const AgentConfig& config, const Creative& creative,
+            const Json::Value& crIds) const
+    {
+        ExcAssert(crIds.isObject());
+
+        using std::find_if;
+        using std::begin;   using std::end;
+
+        for (auto it = crIds.begin(), end = crIds.end(); it != end; ++it) {
+            auto key = it.memberNameC();
+            try {
+                if (string_int_equals(key, config.externalId)) {
+                    const auto& crids = *it;
+                    return find_if(crids.begin(), crids.end(), [&](const Json::Value& value) {
+                        return value.isIntegral() && value.asInt() == creative.id;
+                    }) != crids.end();
+                }
+            } catch (const std::invalid_argument&) {
+                return false;
+            }
         }
 
         return false;


### PR DESCRIPTION
The HttpBidderInterface now tags the BidRequest with the creative-ids
rather than creative-indexes (Breaking Change)
The CreativeIdsExchangeFilter now avoids to allocate when comparing the
ids. Instead, it uses a custom inplace string -< int comparaison
function to avoid converting an int to a string and then using strcmp