### PR TITLE
HttpBidderInterface: make sure to tag all the impressions.

### DIFF
--- a/rtbkit/plugins/exchange/rtbkit_exchange_connector.h
+++ b/rtbkit/plugins/exchange/rtbkit_exchange_connector.h
@@ -96,6 +96,8 @@ private:
     bool filterExternalIds(
             const AgentConfig& config, const Json::Value& extIds) const
     {
+        if (JML_UNLIKELY(extIds.isNull())) return false;
+
         ExcAssert(extIds.isArray());
 
         using std::find_if;
@@ -114,6 +116,8 @@ private:
             const AgentConfig& config, const Creative& creative,
             const Json::Value& crIds) const
     {
+        if (JML_UNLIKELY(crIds.isNull())) return false;
+
         ExcAssert(crIds.isObject());
 
         using std::find_if;

--- a/rtbkit/testing/bid_stack.h
+++ b/rtbkit/testing/bid_stack.h
@@ -18,6 +18,7 @@ namespace RTBKIT {
 
 struct BidStack {
     std::shared_ptr<ServiceProxies> proxies;
+    bool enforceAgents;
 
     // components
     struct Services {
@@ -29,9 +30,10 @@ struct BidStack {
 
     Json::Value bidderConfig;
 
-    BidStack() {
-        proxies.reset(new ServiceProxies());
-    }
+    BidStack()
+     : proxies(new ServiceProxies())
+     , enforceAgents(true)
+    { }
 
     void run(Json::Value const & routerConfig,
              Json::Value const & bidderConfig,
@@ -105,7 +107,7 @@ struct BidStack {
         mock += "]}";
 
         // This is our bidding agent, that actually calculates the bid price
-        if(services.agents.empty()) {
+        if(services.agents.empty() && enforceAgents) {
             auto agent = std::make_shared<TestAgent>(proxies, "agent");
             agent->bidWithFixedAmount(amount);
             services.agents.push_back(agent);

--- a/rtbkit/testing/bidder_test.cc
+++ b/rtbkit/testing/bidder_test.cc
@@ -15,9 +15,12 @@
 #include "rtbkit/plugins/exchange/rtbkit_exchange_connector.h"
 #include "rtbkit/testing/bid_stack.h"
 #include "rtbkit/plugins/bidder_interface/multi_bidder_interface.h"
+#include "rtbkit/openrtb/openrtb_parsing.h"
+#include "rtbkit/plugins/exchange/http_auction_handler.h"
 
 using namespace Datacratic;
 using namespace RTBKIT;
+using namespace std;
 
 BOOST_AUTO_TEST_CASE( bidder_http_test )
 {
@@ -282,4 +285,136 @@ BOOST_AUTO_TEST_CASE( multi_bidder_test )
    int downstreamBidCount = downstreamEvents["router.bid"];
    std::cerr << "DOWNSTREAM BID COUNT=" << downstreamBidCount << std::endl;
    BOOST_CHECK(downstreamBidCount > 0);
+}
+
+struct DummyExchangeConnector : public OpenRTBExchangeConnector
+{
+    DummyExchangeConnector(ServiceBase & owner, const std::string & name)
+        : OpenRTBExchangeConnector(owner, name)
+    { }
+
+    DummyExchangeConnector(const std::string & name,
+                             std::shared_ptr<ServiceProxies> proxies)
+        : OpenRTBExchangeConnector(name, proxies)
+    { }
+
+    std::string exchangeName() const { return "dummy"; }
+
+    std::shared_ptr<BidRequest>
+    parseBidRequest(HttpAuctionHandler& connection,
+                    const HttpHeader& header,
+                    const std::string& payload) {
+        auto request = OpenRTBExchangeConnector::parseBidRequest(connection, header, payload);
+
+        for (const auto& imp: request->imp) {
+            BOOST_CHECK(imp.ext.isMember("creative-ids"));
+            BOOST_CHECK(imp.ext.isMember("external-ids"));
+        }
+
+        return request;
+    }
+};
+
+// Test to validate that every impression in a single BidRequest gets tagged with
+// the "external-ids" and "creative-ids" extension fields, by the HttpBidderInterface
+BOOST_AUTO_TEST_CASE( test_http_bidder_multiple_impressions_tagging )
+{
+    ML::Watchdog watchdog(10.0);
+
+    auto proxies = make_shared<ServiceProxies>();
+    auto acs = make_shared<AgentConfigurationService>(proxies, "acs");
+    acs->unsafeDisableMonitor();
+    acs->init();
+    acs->bindTcp();
+    acs->start();
+
+    Json::Value downstreamBidderConfig;
+    downstreamBidderConfig["type"] = "agents";
+
+    auto router = make_shared<Router>(proxies, "router");
+    router->unsafeDisableMonitor();
+    router->initBidderInterface(downstreamBidderConfig);
+    router->init();
+    router->setBanker(make_shared<NullBanker>(true));
+    router->bindTcp();
+    router->start();
+
+    auto dummyExchange = new DummyExchangeConnector("dummyExchange", proxies);
+    dummyExchange->start();
+    dummyExchange->enableUntil(Date::positiveInfinity());
+    router->addExchange(dummyExchange);
+
+    Json::Value upstreamRouterConfig;
+    upstreamRouterConfig[0]["exchangeType"] = "openrtb";
+
+    Json::Value upstreamBidderConfig;
+    upstreamBidderConfig["type"] = "http";
+    upstreamBidderConfig["adserver"]["winPort"] = 18143;
+    upstreamBidderConfig["adserver"]["eventPort"] = 18144;
+
+    upstreamBidderConfig["router"]["host"] = "http://127.0.0.1:" + to_string(dummyExchange->port());
+    upstreamBidderConfig["router"]["path"] = "/";
+    upstreamBidderConfig["adserver"]["host"] = "http://invalid-url-but-its-intended.com";
+
+    Json::Value httpAgentConfig = Json::parse(
+        R"JSON(
+        {
+            "account": ["dummy_account"],
+            "bidProbability": 1,
+            "creatives": [ { "width": 300, "height": 250, "id": 1 } ],
+            "externalId": 1
+        }
+        )JSON");
+
+    BidStack upstreamStack;
+    upstreamStack.enforceAgents = false;
+
+    upstreamStack.runThen(
+            upstreamRouterConfig, upstreamBidderConfig, USD_CPM(10), 0,
+            [&](const Json::Value& json) {
+
+        upstreamStack.postConfig("sample_http_config", httpAgentConfig);
+
+        ML::sleep(1.0);
+
+        ML::RNG rng;
+        OpenRTB::BidRequest req;
+        req.id = Id(rng.random());
+        req.tmax.val = 50;
+        req.at = AuctionType::SECOND_PRICE;
+
+        req.imp.emplace_back();
+        {
+            auto& imp = req.imp.back();
+            imp.id = Id(rng.random());
+            imp.banner.reset(new OpenRTB::Banner);
+            imp.banner->w.push_back(300);
+            imp.banner->h.push_back(250);
+        }
+
+        req.imp.emplace_back();
+        {
+            auto& imp = req.imp.back();
+            imp.id = Id(rng.random());
+            imp.banner.reset(new OpenRTB::Banner);
+            imp.banner->w.push_back(600);
+            imp.banner->h.push_back(400);
+        }
+
+        StructuredJsonPrintingContext context;
+        DefaultDescription<OpenRTB::BidRequest> desc;
+        desc.printJson(&req, context);
+
+        auto bids = json["workers"][0]["bids"];
+        auto url = bids["url"].asString();
+        auto resource = bids.get("resource", "/").asString();
+
+        HttpRestProxy proxy(url);
+        auto response = proxy.post(
+                resource, context.output,
+                RestParams() /* queryParams */,
+                { { "x-openrtb-version", "2.2" } });
+
+    });
+
 }


### PR DESCRIPTION
For BidRequests with multiple impressions, the HttpBidderInterface might
not tag impressions that have no potential bidders. If used with the
RTBKitExchangeConnector and the CreativeIdsExchangeFilter, this might be
bad because the filter expects that every impression contains at least
an "external-ids" or "creative-ids" extension field. For impressions
that didn't satisfy filters, we now tag them with null values